### PR TITLE
feat (ci): add `wait-for-postgres` script

### DIFF
--- a/infra/compose.yaml
+++ b/infra/compose.yaml
@@ -1,5 +1,6 @@
 services: 
   database:
+    container_name: "postgres-dev"
     image: 'postgres:16.0-alpine3.18'
     env_file: 
       - ../.env.development

--- a/infra/scripts/wait-for-postgres.js
+++ b/infra/scripts/wait-for-postgres.js
@@ -1,0 +1,17 @@
+const { exec } = require('node:child_process')
+function checkPostgres() {
+  exec('docker exec postgres-dev pg_isready --host localhost', handleReturn)
+  function handleReturn(err, stdout, stderr) { 
+    if (stdout.search("accepting connections") === -1) {
+      process.stdout.write(".")
+      checkPostgres()
+      return
+    } 
+    process.stdout.write("\n");
+    console.log("\n✅ Postgres is ready and accepting connections\n")
+  }
+}
+process.stdout.write("\n\n🛑 Waiting for postgres to accept connections")
+
+checkPostgres();
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A tabnews.com.br implementation",
   "main": "index.js",
   "scripts": {
-    "dev": "npm run services:up && next dev",
+    "dev": "npm run services:up && npm run wait-for-postgres && npm run migration:up && next dev",
     "services:up": "docker compose -f infra/compose.yaml up -d",
     "services:stop": "docker compose -f infra/compose.yaml stop",
     "services:down": "docker compose -f infra/compose.yaml down",
@@ -13,7 +13,8 @@
     "test": "jest --runInBand",
     "test:watch": "jest --watchAll --runInBand",
     "migration:create": "node-pg-migrate -m infra/migrations create",
-    "migration:up": "node-pg-migrate -m infra/migrations --envPath .env.development up"
+    "migration:up": "node-pg-migrate -m infra/migrations --envPath .env.development up",
+    "wait-for-postgres": "node infra/scripts/wait-for-postgres.js"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
This adds `wait-for-postgres` script to allow `npm run dev` to fully setup the dev environment before every run no matter what is the application status.